### PR TITLE
Update COMMON.md

### DIFF
--- a/COMMON.md
+++ b/COMMON.md
@@ -43,11 +43,11 @@ Should you have better proposals or doubts, please feel free to comment ono each
  * **data store** -> *archivio dati*
  * **dropdown menu** -> *menù a discesa*, *menù a tendina*
  * **features** -> *funzionalità/caratteristiche*
- * **helper** -> *supporto* depending on the context
+ * **helper** -> *utilità/classe di utilità* depending on the context
  * **link(s)** -> *collegamento/collegamenti*
  * **package** -> *pacchetto*
  * **path** -> *percorso*, *indirizzo*
- * **pattern** -> *schema*
+ * **pattern** -> *schema ricorrente*
  * **publication** -> *pubblicazione*
  * **real-time** -> *tempo reale*
  * **subscription** -> *sottoscrizione*


### PR DESCRIPTION
Hi,
I would like to propose two different translations for some common terms in COMMON.md:

helper -> utilità / classe di utilità

Currently is supporto, but I think - for instance when used with template - that the translation should be closer to the literal of "helper class"...

pattern -> schema ricorrente

Currently is only schema, but schema may be confused with other concepts, like database schema, which in my opinion are more commonly used and known in the tecnical context of applications development.
